### PR TITLE
#117 move long descriptions to purpose field

### DIFF
--- a/input/fsh/moped-operation-aufnehmen.fsh
+++ b/input/fsh/moped-operation-aufnehmen.fsh
@@ -1,7 +1,9 @@
 Instance: MOPEDPatientAufnehmen
 InstanceOf: OperationDefinition
 Title: "MOPED Patient $aufnehmen (POC)"
-Description: """
+Description: "Die $aufnehmen Operation wird aufgerufen, wenn ein(e) Patient*in in das Krankenhaus aufgenommen wird."
+Usage: #definition
+* purpose = """
 **Wer ruft diese Operation in welchem Zusammenhang auf?**
 
 Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die $aufnehmen Operation wird aufgerufen, wenn ein(e) Patient*in in das Krankenhaus aufgenommen wird.
@@ -46,8 +48,6 @@ Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die $aufnehmen Operat
 * Hinweis 2: Es ist nicht nötig, bei dieser Operation den GDA-Identifier als Kontext mitzugeben. Auf den GDA wird im *falldaten*-Bundle als conditional Reference mittels entsprechendem Identifier im MOPEDEncounter verwiesen. Somit wird auch vermieden, dass Duplikate einer GDA-Organization-Ressource am Server angelegt/verwendet werden.
 * Hinweis 3: Im Parameter *falldaten* wird unter Anderem eine Coverage Ressource mitgegeben. Diese Ressource stammt in der Regel aus einer erfolgreichen VDAS-Abfrage. In Zukunft wird Moped auch andere Optionen unterstützen, wie die Verarbeitung von Daten von Selbstzahlern (wofür ein separates Coverage-Profil angelegt wird), oder die Verarbeitung von Fällen mit privater Krankenversicherung (auch hierfür wird ein separates Coverage-Profil angelegt). Im Ersten Schritt liegt der Fokus auf den Standard-Fall, der als Ausgangsbasis eine erfolgreich abgeschlossene VDAS-Abfrage voraussetzt.
 """
-Usage: #definition
-
 * id = "MOPED.Patient.Aufnehmen"
 * base = "http://hl7.org/fhir/OperationDefinition/Patient-aufnehmen"
 * name = "MOPED_Patient_Aufnehmen"

--- a/input/fsh/moped-operation-entlassen.fsh
+++ b/input/fsh/moped-operation-entlassen.fsh
@@ -1,7 +1,9 @@
 Instance: MOPEDPatientEntlassen
 InstanceOf: OperationDefinition
 Title: "MOPED Patient $entlassen (POC)"
-Description: """
+Description: "Die $entlassen Operation wird aufgerufen, wenn ein(e) Patient*in aus dem Krankenhaus entlassen wurde."
+Usage: #definition
+* purpose = """
 
 **Wer ruft diese Operation in welchem Zusammenhang auf?**
 
@@ -40,7 +42,6 @@ Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die $entlassen Operat
 
 * Hinweis 1: Wurde der Patient direkt aus der Intensivstation entlassen, so müsste auch eine Abgangsart im MOPEDTransferEncounter gesetzt werden. Dieser Spezialfall wurde noch nicht berücksichtigt.
 """
-Usage: #definition
 
 * id = "MOPED.Patient.Entlassen"
 * base = "http://hl7.org/fhir/OperationDefinition/Patient-entlassen"

--- a/input/fsh/moped-operation-kostenuebernahme-anfragen.fsh
+++ b/input/fsh/moped-operation-kostenuebernahme-anfragen.fsh
@@ -1,7 +1,10 @@
 Instance: VersichertenanspruchserklärungAnfragen
 InstanceOf: OperationDefinition
 Title: "MOPED Versichertenanspruchserklärung $anfragen (POC)"
-Description: """
+Description: "Die Versichertenanspruchserklärung $anfragen Operation wird aufgerufen, um die Versichertenanspruchserklärung-Anfrage an die SV anzustoßen. Diese Operation ist irrelevant für Selbstzahler (das ist wichtig für künftige weiterentwicklung - wenn im Account auf eine Coverage-Ressource für Selbstzahler referenziert wird, darf die Operation $anfragen nicht ausgeführt werden)."
+Usage: #definition 
+* purpose = """
+Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. 
 
 **Wer ruft diese Operation in welchem Zusammenhang auf?**
 
@@ -39,8 +42,6 @@ Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die Versichertenanspr
 
 * Hinweis 1: Nach dieser Operation findet lt. Soll-Prozess kein Update des Status *MOPEDAccount.workflowStatus* statt.
 """
-Usage: #definition 
-
 * id = "MOPED.CoverageEligibilityRequest.Anfragen"
 * base = "http://hl7.org/fhir/OperationDefinition/CoverageEligibilityRequest-anfragen"
 * comment = "TBD: Ist hier evtl. eine Transaction die bessere Lösung? Bei dieser Operation findet keine Status-Änderung statt. Lediglich auf die Precondition des Workflow-Status müsste geachtet werden."

--- a/input/fsh/moped-operation-kostenuebernahmeanfrage-checkstatus.fsh
+++ b/input/fsh/moped-operation-kostenuebernahmeanfrage-checkstatus.fsh
@@ -1,8 +1,9 @@
 Instance: VersichertenanspruchserklärungAnfrageCheckStatus
 InstanceOf: OperationDefinition
 Title: "Versichertenanspruchserklärung-Anfrage $checkStatus"
-Description: """
-Die Versichertenanspruchserklärung-Anfrage $checkStatus Operation wird aufgerufen, um zu überprüfen, in welchem Status sich die Bearbeitung seitens SV derzeit befindet. Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen.
+Description: "Die Versichertenanspruchserklärung-Anfrage $checkStatus Operation wird aufgerufen, um zu überprüfen, in welchem Status sich die Bearbeitung seitens SV derzeit befindet. Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen."
+Usage: #definition 
+* purpose = """Die Versichertenanspruchserklärung-Anfrage $checkStatus Operation wird aufgerufen, um zu überprüfen, in welchem Status sich die Bearbeitung seitens SV derzeit befindet. Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen.
 
 1. Suchen des MOPEDAccounts: Über die Referenz der Ressource *MOPEDEncounter.account*. Dabei handelt es sich um jenen Encounter, der den *aufnahmezahl* Parameter als *identifier* gespeichert hat. 
 2. Suchen des Requests: Es geht um jenen Request, der in *MOPEDAccount.coverageEligibilityRequest* Feld referenziert wurde
@@ -12,8 +13,6 @@ Die Versichertenanspruchserklärung-Anfrage $checkStatus Operation wird aufgeruf
      * *draft*: Draft in Kombination mit dem *outcome*-Wert *queued* heißt, dass die SV den jeweiligen Request bereits ausgeliefert bekommen hat, jedoch die Bearbeitung noch nicht begonnen hat. Ein *draft*-Status in Kombination mit einem anderen *outcome*-Wert ist ungültig und sollte zu einer Fehlermeldung führen.
      * *active*: Active in Kombination mit dem *outcome*-Wert *queued* bedeutet, dass die SV aktiv gestartet hat, den CoverageEligibilityRequest zu bearbeiten, es jedoch noch kein Resultat gibt. Ist der *outcome* mit dem Wert *completed*, *error* oder *partial* befüllt, ist die SV mit der Response fertig und eine Meldung kann ausgegeben werden, dass die freigegebene CoverageEligibilityResponse vom Krankenhaus abgeholt werden kann. 
 """
-Usage: #definition 
-
 * id = "MOPED.CoverageEligibilityRequest.CheckStatus"
 * base = "http://hl7.org/fhir/OperationDefinition/CoverageEligibilityRequest-checkStatus"
 * name = "MOPED_CoverageEligibilityRequest_Check_Status"

--- a/input/fsh/moped-operation-kostenuebernahmeanfragen-abholen.fsh
+++ b/input/fsh/moped-operation-kostenuebernahmeanfragen-abholen.fsh
@@ -1,7 +1,9 @@
 Instance: VersichertenanspruchserklärungAnfragenAbholen
 InstanceOf: OperationDefinition
 Title: "Versichertenanspruchserklärung-Anfragen $abholen"
-Description: """
+Description: "Die Versichertenanspruchserklärung-Anfragen $abholen Operation wird aufgerufen, um alle noch offenen Versichertenanspruchserklärung-Anfragen, die bisher seitens SV noch nicht bearbeitet wurden, abgeholt werden können."
+Usage: #definition 
+* purpose = """
 Die Operation wird vom Akteur Sozialversicherung (SV) aufgerufen. Die Versichertenanspruchserklärung-Anfragen $abholen Operation wird aufgerufen, um alle noch offenen Versichertenanspruchserklärung-Anfragen, die bisher seitens SV noch nicht bearbeitet wurden, abgeholt werden können.
 1. Suche nach relevanten Requests: Alle CoverageEligibilityRequests, 
   * die im Feld *CoverageEligibilityRequest.insurer* die Organization mit *Organization.identifier* = Operation-Parameter *versicherer* referenziert haben UND
@@ -13,7 +15,7 @@ Die Operation wird vom Akteur Sozialversicherung (SV) aufgerufen. Die Versichert
    * mit Feld *CoverageEligibilityResponse.request* = Referenz auf jeweiligen Request
    * mit Feld *CoverageEligibilityResponse.outcome* = *queued*
 """
-Usage: #definition 
+
 
 * id = "MOPED.CoverageEligibilityRequest.Abholen"
 * base = "http://hl7.org/fhir/OperationDefinition/CoverageEligibilityRequest-abholen"

--- a/input/fsh/moped-operation-verlegen.fsh
+++ b/input/fsh/moped-operation-verlegen.fsh
@@ -1,8 +1,9 @@
 Instance: MOPEDPatientVerlegen
 InstanceOf: OperationDefinition
 Title: "MOPED Patient $verlegen (POC)"
-Description: """
-
+Description: "Die $verlegen Operation wird aufgerufen, wenn ein(e) Patient*in auf eine andere Station verlegt wird. Auch initial, wenn ein Patient auf eine bestimmte Station aufgenommen wird, wird diese Operation aufgerufen (dies passiert automatisch im Zuge der Operation $aufnehmen)."
+Usage: #definition
+* purpose = """
 **Wer ruft diese Operation in welchem Zusammenhang auf?**
 
 Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die $verlegen Operation wird aufgerufen, wenn ein(e) Patient*in auf eine andere Station verlegt wird. Auch initial, wenn ein Patient auf eine bestimmte Station aufgenommen wird, wird diese Operation aufgerufen (dies passiert automatisch im Zuge der Operation $aufnehmen).
@@ -58,7 +59,6 @@ Die Operation wird vom Akteur Krankenhaus (KH) aufgerufen. Die $verlegen Operati
 * Hinweis 3: Der Counter für AnzahlVerlegungen wird auch im Falle einer Beurlaubung erhöht, bei der eine reguläre Verlegung-Operation aufgerufen wird.
 
 """
-Usage: #definition
 
 * id = "MOPED.Patient.Verlegen"
 * base = "http://hl7.org/fhir/OperationDefinition/Patient-verlegen"


### PR DESCRIPTION
Hab herausgefunden, dass es ein Field names Purpose gibt, in des wir die längeren Beschreibungen geben können.
Sieht dann so im Artifacts Tab aus: 
![grafik](https://github.com/user-attachments/assets/7fa2a294-5340-4933-a6b3-cdf1f64d9c98)
Und so sieht dann die Seite aus:
![grafik](https://github.com/user-attachments/assets/6b5f6c78-acac-4feb-b96d-32d5c720dd47)

Hab jetzt einfach immer einen der ersten Sätze in den alten Beschreibungen als neue Beschreibung genommen. Nur um zu testen ob's geht. Kann mir da gerne noch bessere Beschreibungen ausdenken.

closes #117 