### PR TITLE
229 profile für den patient für die einzelnen rollen erstellen

### DIFF
--- a/input/fsh/moped-encounter.fsh
+++ b/input/fsh/moped-encounter.fsh
@@ -46,7 +46,7 @@ Description: "MOPED Profil der Encounter Ressource für die Krankenanstaltenaufn
 * reason[Ursache].value from UrsacheValueSet (required)
 * reason[Ursache] ^short = "Ursache für Behandlung"
 
-* diagnosis.use from https://termgit.elga.gv.at/ValueSet/lkf-diagnose-typ (required)
+* diagnosis.use from $LKFdiagnoseTyp (required)
 * diagnosis.use ^binding.description = "Code für den Typ der LKF Diagnose, der angibt ob es sich um eine Haupt- oder Nebendiagnose handelt"
 
 * admission.extension contains Zugangsart named Zugangsart 0..1

--- a/input/fsh/moped-patient-LGF.fsh
+++ b/input/fsh/moped-patient-LGF.fsh
@@ -1,0 +1,13 @@
+Profile: MOPEDPatientLGF
+Parent: HL7ATCorePatient
+Title: "MOPED Patient LGF"
+Description: "MOPED Profil der Patient Ressource aus der Sicht der Rolle: LGF"
+
+* extension[PatientReligion] 0..0
+* identifier[socialSecurityNumber] 0..0
+* name.extension contains DataAbsentReason named data-absent-reason 1..1
+* name.extension[DataAbsentReason].valueCode = http://hl7.org/fhir/StructureDefinition/data-absent-reason#masked
+* telecom 0..0
+* address.line 0..0
+* address.city 0..0
+* address.text 0..0

--- a/input/fsh/moped-patient-SV.fsh
+++ b/input/fsh/moped-patient-SV.fsh
@@ -1,0 +1,7 @@
+Profile: MOPEDPatientSV
+Parent: HL7ATCorePatient
+Title : "MOPED Patient SV"
+Description: "MOPED Profil der Patient Ressource aus der Sicht der Rolle: SV"
+
+* address.extension[municipalityCode] 0..0
+* contact.address.extension[municipalityCode] 0..0

--- a/input/fsh/moped-patient-bund.fsh
+++ b/input/fsh/moped-patient-bund.fsh
@@ -1,0 +1,14 @@
+Profile: MOPEDPatientBund
+Parent: HL7ATCorePatient
+Title: "MOPED Patient Bund"
+Description: "MOPED Profil der Patient Ressource aus der Sicht der Rolle: Bund"
+
+* extension[PatientReligion] 0..0
+* identifier[socialSecurityNumber] 0..0
+* name.extension contains DataAbsentReason named data-absent-reason 1..1
+* name.extension[DataAbsentReason].valueCode = http://hl7.org/fhir/StructureDefinition/data-absent-reason#masked
+* telecom 0..0
+* address.line 0..0
+* address.city 0..0
+* address.text 0..0
+* birthDate 0..0


### PR DESCRIPTION
#229 
@alackerbauer Sollen die Profile der einzelnen Rollen nur die Felder verbieten die explizit verboten sind? oder so restriktiv sein, dass gar nichts anderes drinnen stehen darf außer die erlaubten Felder?

momentan sind nur die Felder gestrichen, die explizit "verboten" sind + telecom bei LGF und Bund