### PR TITLE
230 Encounter profile für die Rollen Bund, LGF und SV hinzufügen

### DIFF
--- a/input/fsh/moped-encounter-LGF.fsh
+++ b/input/fsh/moped-encounter-LGF.fsh
@@ -1,0 +1,8 @@
+Profile: MOPEDEncounterLGF
+Parent: MOPEDEncounter
+Title: "MOPED Encounter LGF"
+Description: "MOPED Profil der Encounter Ressource für die Rolle: LGF"
+
+* identifier[DatensatzID] 0..0
+* reason[Ursache] 0..0
+* extension[Unfalldatum] 0..0

--- a/input/fsh/moped-encounter-SV.fsh
+++ b/input/fsh/moped-encounter-SV.fsh
@@ -1,0 +1,11 @@
+Profile: MOPEDEncounterSV
+Parent: MOPEDEncounter
+Title: "MOPED Encounter SV"
+Description: "MOPED Profil der Encounter Ressource für die Rolle: SV"
+
+* identifier[DatensatzID] 0..0
+* class[Behandlungsart] 0..0
+* class[Aufnahmeart] 0..0
+* diagnosis.use 0..0
+* admission.extension[Transportart] 0..0
+* admission.destination 0..0

--- a/input/fsh/moped-encounter-bund.fsh
+++ b/input/fsh/moped-encounter-bund.fsh
@@ -1,0 +1,8 @@
+Profile: MOPEDEncounterBund
+Parent: MOPEDEncounter
+Title: "MOPED Encounter Bund"
+Description: "MOPED Profil der Encounter Ressource für die Rolle: Bund"
+
+* identifier[Aufnahmezahl] 0..0
+* reason[Ursache] 0..0
+* extension[Unfalldatum] 0..0


### PR DESCRIPTION
#230
@alackerbauer Sollen die Profile der einzelnen Rollen nur die Felder verbieten die explizit verboten sind? oder so restriktiv sein, dass gar nichts anderes drinnen stehen darf außer die erlaubten Felder?

momentan sind nur die Felder gestrichen, die explizit "verboten" sind