### PR TITLE
310 register questionares

### DIFF
--- a/input/fsh/questionnaires/RegisterQuestionnaire.fsh
+++ b/input/fsh/questionnaires/RegisterQuestionnaire.fsh
@@ -34,18 +34,26 @@ Usage: #example
 * item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 
 * item[+].type = #string
-* item[=].maxLength = 4
-* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
-* item[=].extension.valueInteger = 4
-* item[=].text = "Abteilungsnummer"
-* item[=].required = true
+* item[=].maxLength = 172
+* item[=].linkId = "550421449451"
+* item[=].text = "VBPK-AS"
+* item[=].required = false
+* item[=].item.type = #display
+* item[=].item.text = "verschlüsseltes bereichsspezifisches Personenkennzeichen Amtliche Statistik"
+* item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
+* item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 
 * item[+].type = #string
-* item[=].maxLength = 2
+* item[=].maxLength = 10
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
-* item[=].extension.valueInteger = 2
-* item[=].text = "Subcode zur Abteilungsnummer"
-* item[=].required = true
+* item[=].extension.valueInteger = 10
+* item[=].text = "Sozialversicherungsnummer"
+* item[=].enableWhen.question = "550421449451"
+* item[=].enableWhen.operator = #exists
+* item[=].enableWhen.answerBoolean = false
+* item[=].enableBehavior = #any
+* item[=].required = false
 
 * item[+].type = #date
 * item[=].text = "Aufenthalt am"
@@ -61,10 +69,10 @@ Usage: #example
 * item[=].extension.valueCodeableConcept = $questionnaire-item-control#drop-down "Drop down"
 * item[=].text = "Histopathologisches Grading"
 * item[=].required = true
-* item[=].answerOption[0].valueCoding = #1 "Grad I gut differenziert differenziert o.n.A."
-* item[=].answerOption[+].valueCoding = #2 "Grad II mäßig differenziert mäßig gut differenziert mittelgradig differenziert"
-* item[=].answerOption[+].valueCoding = #3 "Grad III schlecht differenziert"
-* item[=].answerOption[+].valueCoding = #4 "Grad IV undifferenziert anaplastisch"
+* item[=].answerOption[0].valueCoding = #1 "\"Grad I gut differenziert differenziert o.n.A.\""
+* item[=].answerOption[+].valueCoding = #2 "\"Grad II mäßig differenziert mäßig gut differenziert mittelgradig differenziert\""
+* item[=].answerOption[+].valueCoding = #3 "\"Grad III schlecht differenziert\""
+* item[=].answerOption[+].valueCoding = #4 "\"Grad IV undifferenziert anaplastisch\""
 * item[=].answerOption[+].valueCoding = #9 "Grading bzw. Bestimmung des Zelltyps nicht durchgeführt, nicht angegeben oder entfällt"
 
 * item[+].type = #choice
@@ -92,7 +100,7 @@ Usage: #example
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].extension.valueCodeableConcept = $questionnaire-item-control#check-box "Check-box"
 * item[=].text = "Behandlung"
-* item[=].required = true
+* item[=].required = false
 * item[=].repeats = true
 * item[=].answerOption[0].valueCoding = #00 "sonstige (7)"
 * item[=].answerOption[+].valueCoding = #10 "chirurgisch radikal (1)"

--- a/input/fsh/questionnaires/RegisterQuestionnaire.fsh
+++ b/input/fsh/questionnaires/RegisterQuestionnaire.fsh
@@ -1,0 +1,103 @@
+Alias: $questionnaire-item-control = http://hl7.org/fhir/questionnaire-item-control
+
+Instance: register-questionnaire
+InstanceOf: Questionnaire
+Usage: #example
+* title = "register-questionnaire"
+* status = #draft
+
+* item[0].type = #string
+* item[=].maxLength = 100
+* item[=].text = "Personennummer"
+* item[=].required = false
+
+* item[0].type = #string
+* item[=].maxLength = 100
+* item[=].text = "Tumornummer"
+* item[=].required = false
+
+* item[0].type = #string
+* item[=].maxLength = 100
+* item[=].text = "Meldungsnummer"
+* item[=].required = false
+
+* item[+].type = #string
+* item[=].maxLength = 4
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
+* item[=].extension.valueInteger = 4
+* item[=].text = "Anstaltsnummer"
+* item[=].required = true
+* item[=].item.type = #display
+* item[=].item.text = "Code bei Statistik Austria anfordern"
+* item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
+* item[=].item.extension.valueCodeableConcept.text = "Help-Button"
+
+* item[+].type = #string
+* item[=].maxLength = 4
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
+* item[=].extension.valueInteger = 4
+* item[=].text = "Abteilungsnummer"
+* item[=].required = true
+
+* item[+].type = #string
+* item[=].maxLength = 2
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
+* item[=].extension.valueInteger = 2
+* item[=].text = "Subcode zur Abteilungsnummer"
+* item[=].required = true
+
+* item[+].type = #date
+* item[=].text = "Aufenthalt am"
+* item[=].required = true
+* item[=].item.type = #display
+* item[=].item.text = "Datum des Patientenkontakts"
+* item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
+* item[=].item.extension.valueCodeableConcept.text = "Help-Button"
+
+* item[+].type = #choice
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].extension.valueCodeableConcept = $questionnaire-item-control#drop-down "Drop down"
+* item[=].text = "Histopathologisches Grading"
+* item[=].required = true
+* item[=].answerOption[0].valueCoding = #1 "Grad I gut differenziert differenziert o.n.A."
+* item[=].answerOption[+].valueCoding = #2 "Grad II mäßig differenziert mäßig gut differenziert mittelgradig differenziert"
+* item[=].answerOption[+].valueCoding = #3 "Grad III schlecht differenziert"
+* item[=].answerOption[+].valueCoding = #4 "Grad IV undifferenziert anaplastisch"
+* item[=].answerOption[+].valueCoding = #9 "Grading bzw. Bestimmung des Zelltyps nicht durchgeführt, nicht angegeben oder entfällt"
+
+* item[+].type = #choice
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].extension.valueCodeableConcept = $questionnaire-item-control#drop-down "Drop down"
+* item[=].text = "Diagnosestellung"
+* item[=].required = true
+* item[=].answerOption[0].valueCoding = #1 "rein klinisch"
+* item[=].answerOption[+].valueCoding = #2 "mit klinischen Hilfsmitteln"
+* item[=].answerOption[+].valueCoding = #3 "endoskopisch"
+* item[=].answerOption[+].valueCoding = #4 "explorativ-operativ"
+* item[=].answerOption[+].valueCoding = #5 "zytologisch"
+* item[=].answerOption[+].valueCoding = #6 "bioptisch"
+* item[=].answerOption[+].valueCoding = #7 "operativ"
+* item[=].answerOption[+].valueCoding = #8 "autoptisch"
+* item[=].answerOption[+].valueCoding = #9 "unbekannt"
+* item[=].answerOption[=].initialSelected = true
+* item[=].item.type = #display
+* item[=].item.text = "Art der Diagnose, die letztendlich zur Diagnosestellung geführt hat."
+* item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
+* item[=].item.extension.valueCodeableConcept.text = "Help-Button"
+
+* item[+].type = #choice
+* item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+* item[=].extension.valueCodeableConcept = $questionnaire-item-control#check-box "Check-box"
+* item[=].text = "Behandlung"
+* item[=].required = true
+* item[=].repeats = true
+* item[=].answerOption[0].valueCoding = #00 "sonstige (7)"
+* item[=].answerOption[+].valueCoding = #10 "chirurgisch radikal (1)"
+* item[=].answerOption[+].valueCoding = #20 "chirurgisch palliativ (2)"
+* item[=].answerOption[+].valueCoding = #30 "strahlentherapeutisch (3)"
+* item[=].answerOption[+].valueCoding = #40 "chemotherapeutisch (4)"
+* item[=].answerOption[+].valueCoding = #50 "hormonal (5)"
+* item[=].answerOption[+].valueCoding = #60 "immunotherapeutisch (6)"

--- a/input/fsh/questionnaires/RegisterQuestionnaire.fsh
+++ b/input/fsh/questionnaires/RegisterQuestionnaire.fsh
@@ -7,26 +7,31 @@ Usage: #example
 * status = #draft
 
 * item[0].type = #string
+* item[=].linkId = "550421449440"
 * item[=].maxLength = 100
 * item[=].text = "Personennummer"
 * item[=].required = false
 
 * item[0].type = #string
+* item[=].linkId = "550421449441"
 * item[=].maxLength = 100
 * item[=].text = "Tumornummer"
 * item[=].required = false
 
 * item[0].type = #string
+* item[=].linkId = "550421449442"
 * item[=].maxLength = 100
 * item[=].text = "Meldungsnummer"
 * item[=].required = false
 
 * item[+].type = #string
+* item[=].linkId = "550421449443"
 * item[=].maxLength = 4
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
 * item[=].extension.valueInteger = 4
 * item[=].text = "Anstaltsnummer"
 * item[=].required = true
+* item[=].item.linkId = "550421449443_helpText"
 * item[=].item.type = #display
 * item[=].item.text = "Code bei Statistik Austria anfordern"
 * item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
@@ -35,9 +40,10 @@ Usage: #example
 
 * item[+].type = #string
 * item[=].maxLength = 172
-* item[=].linkId = "550421449451"
+* item[=].linkId = "550421449444"
 * item[=].text = "VBPK-AS"
 * item[=].required = false
+* item[=].item.linkId = "550421449444_helpText"
 * item[=].item.type = #display
 * item[=].item.text = "verschlüsseltes bereichsspezifisches Personenkennzeichen Amtliche Statistik"
 * item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
@@ -45,26 +51,30 @@ Usage: #example
 * item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 
 * item[+].type = #string
+* item[=].linkId = "550421449445"
 * item[=].maxLength = 10
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/minLength"
 * item[=].extension.valueInteger = 10
 * item[=].text = "Sozialversicherungsnummer"
-* item[=].enableWhen.question = "550421449451"
+* item[=].enableWhen.question = "550421449444"
 * item[=].enableWhen.operator = #exists
 * item[=].enableWhen.answerBoolean = false
 * item[=].enableBehavior = #any
 * item[=].required = false
 
 * item[+].type = #date
+* item[=].linkId = "550421449446"
 * item[=].text = "Aufenthalt am"
 * item[=].required = true
+* item[=].item.linkId = "550421449446_helpText"
 * item[=].item.type = #display
 * item[=].item.text = "Datum des Patientenkontakts"
 * item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
 * item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 
-* item[+].type = #choice
+* item[+].type = #coding
+* item[=].linkId = "550421449447"
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].extension.valueCodeableConcept = $questionnaire-item-control#drop-down "Drop down"
 * item[=].text = "Histopathologisches Grading"
@@ -75,7 +85,8 @@ Usage: #example
 * item[=].answerOption[+].valueCoding = #4 "\"Grad IV undifferenziert anaplastisch\""
 * item[=].answerOption[+].valueCoding = #9 "Grading bzw. Bestimmung des Zelltyps nicht durchgeführt, nicht angegeben oder entfällt"
 
-* item[+].type = #choice
+* item[+].type = #coding
+* item[=].linkId = "550421449448"
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].extension.valueCodeableConcept = $questionnaire-item-control#drop-down "Drop down"
 * item[=].text = "Diagnosestellung"
@@ -90,13 +101,15 @@ Usage: #example
 * item[=].answerOption[+].valueCoding = #8 "autoptisch"
 * item[=].answerOption[+].valueCoding = #9 "unbekannt"
 * item[=].answerOption[=].initialSelected = true
+* item[=].item.linkId = "550421449448_helpText"
 * item[=].item.type = #display
 * item[=].item.text = "Art der Diagnose, die letztendlich zur Diagnosestellung geführt hat."
 * item[=].item.extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].item.extension.valueCodeableConcept = $questionnaire-item-control#help "Help-Button"
 * item[=].item.extension.valueCodeableConcept.text = "Help-Button"
 
-* item[+].type = #choice
+* item[+].type = #coding
+* item[=].linkId = "550421449449"
 * item[=].extension.url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
 * item[=].extension.valueCodeableConcept = $questionnaire-item-control#check-box "Check-box"
 * item[=].text = "Behandlung"


### PR DESCRIPTION
closes #310 
In diesen PR habe ich verschiedene Felder aus der Indikatoren-liste genommen und in einen Fhir-Fragebogen gegeben. Ich habe versucht alle Datentypen und Sonderregeln die ich gefunden habe abzudecken. 

Bei einer Sache bin ich mir jedoch nicht sicher, wie und ob man die umsetzen kann. Bei der Behandlung hängt das Coding davon ab, welche Kombination an Methoden angekreuzt werden und es sind auch nicht alle Kombinationen möglich. Siehe den Ausschnitt aus dem Datenstruktur Excel:
![grafik](https://github.com/user-attachments/assets/79d4df99-58f1-47c9-a41f-d1115f79e656)

Ich habe jetzt einfach mal nur die verschiedenen Methoden mit Mehrfachauswahl reingegeben. Das Einzige, was mir einfällt, was man noch machen könnte, ist einfach alle Kombinationen, die möglich sein können, mit den et sprechenden Coding aufzulisten.