### PR TITLE
Vorschlag für Coverage Profil

### DIFF
--- a/input/fsh/Alias.fsh
+++ b/input/fsh/Alias.fsh
@@ -2,5 +2,7 @@ Alias: $DiagnoseArt = https://termgit.elga.gv.at/ValueSet/lkf-diagnose-art
 Alias: $LKFdiagnoseTyp = https://termgit.elga.gv.at/ValueSet/lkf-diagnose-typ
 Alias: $ICD10AT = https://termgit.elga.gv.at/CodeSystem/bmg-icd-10-2024
 Alias: $SpezielleOrganisationsform = http://tbd.at/MOPED-SpezielleOrganisationsform
-Alias: $SVCVersichertenkategorien = http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs
+Alias: $SVCVersichertenkategorienCS = http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs
+Alias: $SVCVersichertenkategorienVS = http://svc.co.at/Valueset/ecard-versichertenkategorien-vs
+
 Alias: $LKFLeistungskatalog = https://termgit.elga.gv.at/CodeSystem/lkat-bmsgpk-2025

--- a/input/fsh/examples/Patient Journey 1/PJ1-Coverage.fsh
+++ b/input/fsh/examples/Patient Journey 1/PJ1-Coverage.fsh
@@ -11,6 +11,7 @@ Usage: #example
 * beneficiary.reference = "Patient?identifier=urn:oid:1.2.40.0.10.1.4.3.1|9994210469"
 * subscriber.reference = "Patient?identifier=urn:oid:1.2.40.0.10.1.4.3.1|9994210469"
 * insurer.reference = "Organization?identifier=http://svc.co.at/CodeSystem/ecard-svt-cs|11"
-* class[+].type.coding = http://terminology.hl7.org/CodeSystem/coverage-class#group
-* class[=].value.system = "http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs"
-* class[=].value.value = "01"
+* class[Versichertenkategorien].type.coding = http://terminology.hl7.org/CodeSystem/coverage-class#group
+* class[Versichertenkategorien].value.system = "http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs"
+* class[Versichertenkategorien].value.value = "01"
+* class[Versichertenkategorien].extension[CoverageClassValueCode].valueCodeableConcept.coding = http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs#01

--- a/input/fsh/examples/Patient Journey 2/PJ2-Coverage.fsh
+++ b/input/fsh/examples/Patient Journey 2/PJ2-Coverage.fsh
@@ -11,6 +11,7 @@ Usage: #example
 * beneficiary.reference = "Patient?identifier=urn:oid:1.2.40.0.10.1.4.3.1|324200063"
 * subscriber.reference = "Patient?identifier=urn:oid:1.2.40.0.10.1.4.3.1|324200063"
 * insurer.reference = "Organization?identifier=http://svc.co.at/CodeSystem/ecard-svt-cs|14"
-* class[+].type.coding = http://terminology.hl7.org/CodeSystem/coverage-class#group
-* class[=].value.system = "http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs"
-* class[=].value.value = "01"
+* class[Versichertenkategorien].type.coding = http://terminology.hl7.org/CodeSystem/coverage-class#group
+* class[Versichertenkategorien].value.system = "http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs"
+* class[Versichertenkategorien].value.value = "01"
+* class[Versichertenkategorien].extension[CoverageClassValueCode].valueCodeableConcept.coding = http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs#01

--- a/input/fsh/extensions/moped-ext-CoverageClassValueCode.fsh
+++ b/input/fsh/extensions/moped-ext-CoverageClassValueCode.fsh
@@ -1,0 +1,5 @@
+Extension: CoverageClassValueCode
+Title:    "Codeable Value for Coverage Class"
+Description: "The class.value identifier is not sufficient for our usecase where the class.value should hold a value from a certain ValueSet"
+Context: Coverage.class
+* value[x] only CodeableConcept

--- a/input/fsh/moped-coverage.fsh
+++ b/input/fsh/moped-coverage.fsh
@@ -18,9 +18,15 @@ Title: "MOPED Coverage"
 * class ^slicing.discriminator.path = "type.coding"
 * class ^slicing.ordered = false
 * class ^slicing.rules = #open
+* class.extension contains CoverageClassValueCode named CoverageClassValueCode 0..1
 * class contains
     Versichertenkategorien 0..1 MS
-* class[Versichertenkategorien].type from $SVCVersichertenkategorien (required)
 * class[Versichertenkategorien].type.coding = http://terminology.hl7.org/CodeSystem/coverage-class#group
 * class[Versichertenkategorien] ^short = "Versichertenkategorien"
-* class[Versichertenkategorien].value.system = "http://svc.co.at/CodeSystem/ecard-versichertenkategorie-cs"
+* class[Versichertenkategorien].extension[CoverageClassValueCode].valueCodeableConcept from $SVCVersichertenkategorienVS
+* class[Versichertenkategorien] obeys class-value-matches-extension
+
+Invariant: class-value-matches-extension
+Description: "Falls Coverage.class.extension[CoverageClassValueCode] vorhanden ist, muss Coverage.class.value denselben Code enthalten wie Coverage.class.extension[CoverageClassValueCode].valueCodeableConcept.coding.code."
+Severity: #error
+Expression: "extension.where(url = 'https://elga.moped.at/StructureDefinition/CoverageClassValueCode').valueCodeableConcept.coding.code.contains(value.value)"


### PR DESCRIPTION
nicht mergen: PR erstellt als diskussions basis

um Coverage.class.value codieren zu können;
Invariante wurde mit examples getestet