### PR TITLE
fix most Q&A publisher errors

### DIFF
--- a/input/fsh/questionnaires/StrokeUnitQuestionnaire.fsh
+++ b/input/fsh/questionnaires/StrokeUnitQuestionnaire.fsh
@@ -54,8 +54,8 @@ Usage: #example
         * valueDate = "1900-01-01"
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2026-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today()"
@@ -168,15 +168,15 @@ Usage: #example
       * answerBoolean = true
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2024-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today() - 1 years"
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2026-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today()"
@@ -196,15 +196,15 @@ Usage: #example
       * answerBoolean = true
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2024-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today() - 1 years"
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2026-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today()"
@@ -269,15 +269,15 @@ Usage: #example
       * type = #date
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2015-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today() - 10 years"
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2026-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today()"
@@ -293,15 +293,15 @@ Usage: #example
       * type = #date
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2015-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today() - 10 years"
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2026-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath            
           * valueExpression.expression = "today()"
@@ -708,15 +708,15 @@ Usage: #example
       * type = #date
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2015-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today() - 10 years"
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2026-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today()"
@@ -810,15 +810,15 @@ Usage: #example
         * answerBoolean = true
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2015-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today() - 10 years"
       * extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-        * valueDate = "1900-01-01" // placeholder
-        * extension[+]
+        * valueDate = "2026-01-01" // placeholder
+        * valueDate.extension[+]
           * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
           * valueExpression.language = #text/fhirpath
           * valueExpression.expression = "today()"
@@ -1258,15 +1258,15 @@ Usage: #example
       * answerCoding = #1
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/minValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2015-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today() - 10 years"
     * extension[+]
       * url = "http://hl7.org/fhir/StructureDefinition/maxValue"
-      * valueDate = "1900-01-01" // placeholder
-      * extension[+]
+      * valueDate = "2026-01-01" // placeholder
+      * valueDate.extension[+]
         * url = "http://hl7.org/fhir/StructureDefinition/cqf-calculatedValue"
         * valueExpression.language = #text/fhirpath
         * valueExpression.expression = "today()"


### PR DESCRIPTION
Zwei Errors sind noch übrig - diese hängen aber voneinander ab:
![Screenshot 2025-06-20 at 20 22 33](https://github.com/user-attachments/assets/ea3b1d0b-9405-4b67-b437-9a215ea86591)
 @alackerbauer irgendwelche Ideen?
 
 Die Extension kommt aus dem SDC IG (bisher nur in R4 vielleicht daher): https://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-openLabel.html